### PR TITLE
Rakefile update

### DIFF
--- a/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/.rake_tasks~
+++ b/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/.rake_tasks~
@@ -1,0 +1,2 @@
+db:auto_migrate
+db:auto_upgrade

--- a/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/README.md
+++ b/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/README.md
@@ -1,11 +1,22 @@
 Clone the repo and copy the Skeleton app folder and rename it to your app name.
 
-You will need to create either a skeleton_app_development and skeleton_app_test database or ones with your own title and replace the database names throughout the app to match. If you do make your own they should end in _development and _test to match with the Rack_Env that is in place.
 
-After this run...
+### setup_db
 
+* Run:
 ```
 bundle
+rake helper:setup_db
+rspec
+```
+You should see all tests passing.
+
+* If you'd rather set up the database manually, create two databases, skeleton_app_test and skeleton_app_development, and then run:
+```
+bundle
+rake db:auto_migrate
+rake db:auto_migrate RACK_ENV=test
+rspec
 ```
 
 Feel free to add/improve and make a pull request.

--- a/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/Rakefile
+++ b/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/Rakefile
@@ -16,14 +16,24 @@ namespace :db do
   end
 end
 
-namespace :init do
-  desc "First Time Database Setup"
+namespace :helper do
+  desc "Database creation helper"
   task :create_db do
-    p "Creating skeleton_app_development database..."
+    print "Creating skeleton_app_development database..."
     `psql -c 'CREATE DATABASE skeleton_app_development'`
     puts "Done."
-    p "Creating skeleton_app_test database..."
+    print "Creating skeleton_app_test database..."
     `psql -c 'CREATE DATABASE skeleton_app_test'`
+    puts "Done."
+  end
+
+  desc "Database dropping helper"
+  task :drop_db do
+    print "Dropping skeleton_app_development database..."
+    `psql -c 'DROP DATABASE skeleton_app_development'`
+    puts "Done."
+    print "Dropping skeleton_app_test database..."
+    `psql -c 'DROP DATABASE skeleton_app_test'`
     puts "Done."
   end
 end

--- a/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/Rakefile
+++ b/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/Rakefile
@@ -22,12 +22,10 @@ namespace :helper do
     if db_exists
       puts "WARNING: at least one database with the given name already exists, use $rake helper:drop_db if you want to remove them"
     else
-      print "Creating skeleton_app_development database..."
-      `psql -c 'CREATE DATABASE skeleton_app_development'`
-      puts "Done."
-      print "Creating skeleton_app_test database..."
-      `psql -c 'CREATE DATABASE skeleton_app_test'`
-      puts "Done."
+      create_db 'development'
+      # migrate_db 'development'
+      create_db 'test'
+      # migrate_db 'test'
     end
   end
 
@@ -45,4 +43,10 @@ end
 def db_exists
   `psql -c "SELECT 1 FROM pg_database WHERE datname = 'skeleton_app_test'"`.include? '1' or
   `psql -c "SELECT 1 FROM pg_database WHERE datname = 'skeleton_app_development'"`.include? '1'
+end
+
+def create_db env
+  print "Creating skeleton_app_#{env} database..."
+  `psql -c 'CREATE DATABASE skeleton_app_#{env}'`
+  puts "Done."
 end

--- a/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/Rakefile
+++ b/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/Rakefile
@@ -17,15 +17,15 @@ namespace :db do
 end
 
 namespace :helper do
-  desc "Database creation helper"
-  task :create_db do
+  desc "Database creation and setup helper"
+  task :setup_db do
     if db_exists
       puts "WARNING: at least one database with the given name already exists, use $rake helper:drop_db if you want to remove them"
     else
       create_db 'development'
-      # migrate_db 'development'
+      migrate_db 'development'
       create_db 'test'
-      # migrate_db 'test'
+      migrate_db 'test'
     end
   end
 
@@ -48,5 +48,13 @@ end
 def create_db env
   print "Creating skeleton_app_#{env} database..."
   `psql -c 'CREATE DATABASE skeleton_app_#{env}'`
+  puts "Done."
+end
+
+def migrate_db env
+  print "Migrating skeleton_app_#{env} tables..."
+  DataMapper.setup :default, "postgres://localhost/skeleton_app_#{env}"
+  DataMapper.finalize
+  DataMapper.auto_migrate!
   puts "Done."
 end

--- a/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/Rakefile
+++ b/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/Rakefile
@@ -19,12 +19,16 @@ end
 namespace :helper do
   desc "Database creation helper"
   task :create_db do
-    print "Creating skeleton_app_development database..."
-    `psql -c 'CREATE DATABASE skeleton_app_development'`
-    puts "Done."
-    print "Creating skeleton_app_test database..."
-    `psql -c 'CREATE DATABASE skeleton_app_test'`
-    puts "Done."
+    if db_exists
+      puts "WARNING: at least one database with the given name already exists, use $rake helper:drop_db if you want to remove them"
+    else
+      print "Creating skeleton_app_development database..."
+      `psql -c 'CREATE DATABASE skeleton_app_development'`
+      puts "Done."
+      print "Creating skeleton_app_test database..."
+      `psql -c 'CREATE DATABASE skeleton_app_test'`
+      puts "Done."
+    end
   end
 
   desc "Database dropping helper"
@@ -36,4 +40,9 @@ namespace :helper do
     `psql -c 'DROP DATABASE skeleton_app_test'`
     puts "Done."
   end
+end
+
+def db_exists
+  `psql -c "SELECT 1 FROM pg_database WHERE datname = 'skeleton_app_test'"`.include? '1' or
+  `psql -c "SELECT 1 FROM pg_database WHERE datname = 'skeleton_app_development'"`.include? '1'
 end

--- a/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/Rakefile
+++ b/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/Rakefile
@@ -15,3 +15,15 @@ namespace :db do
     puts "Auto-migrate complete (data was lost), Wayne Rumble was here. LOL"
   end
 end
+
+namespace :init do
+  desc "First Time Database Setup"
+  task :create_db do
+    p "Creating skeleton_app_development database..."
+    `psql -c 'CREATE DATABASE skeleton_app_development'`
+    puts "Done."
+    p "Creating skeleton_app_test database..."
+    `psql -c 'CREATE DATABASE skeleton_app_test'`
+    puts "Done."
+  end
+end

--- a/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/Rakefile
+++ b/Full_Stack_Sinatra_App_Skeletons/Skeleton_App/Rakefile
@@ -31,18 +31,20 @@ namespace :helper do
 
   desc "Database dropping helper"
   task :drop_db do
-    print "Dropping skeleton_app_development database..."
-    `psql -c 'DROP DATABASE skeleton_app_development'`
-    puts "Done."
-    print "Dropping skeleton_app_test database..."
-    `psql -c 'DROP DATABASE skeleton_app_test'`
-    puts "Done."
+    drop_db 'development'
+    drop_db 'test'
   end
 end
 
 def db_exists
   `psql -c "SELECT 1 FROM pg_database WHERE datname = 'skeleton_app_test'"`.include? '1' or
   `psql -c "SELECT 1 FROM pg_database WHERE datname = 'skeleton_app_development'"`.include? '1'
+end
+
+def drop_db env
+  print "Dropping skeleton_app_#{env} database..."
+  `psql -c 'DROP DATABASE skeleton_app_#{env}'`
+  puts "Done."
 end
 
 def create_db env

--- a/Full_Stack_Sinatra_App_Skeletons/Skeleton_App_with_user_login:sign_up_and_bcrypt/README.md
+++ b/Full_Stack_Sinatra_App_Skeletons/Skeleton_App_with_user_login:sign_up_and_bcrypt/README.md
@@ -1,18 +1,22 @@
 Clone the repo and copy the Skeleton app folder and rename it to your app name.
 
-You will need to create either a skeleton_app_development and skeleton_app_test database or ones with your own title and replace the database names throughout the app to match. If you do make your own they should end in _development and _test to match with the Rack_Env that is in place.
 
-After this run...
+### setup_db
 
+* Run:
+```
+bundle
+rake helper:setup_db
+rspec
+```
+You should see all tests passing.
+
+* If you'd rather set up the database manually, create two databases, skeleton_app_test and skeleton_app_development, and then run:
 ```
 bundle
 rake db:auto_migrate
 rake db:auto_migrate RACK_ENV=test
-rake db:auto_upgrade
-rake db:auto_upgrade RACK_ENV=test
 rspec
 ```
-
-You should see all tests passing.
 
 Feel free to add/improve and make a pull request.

--- a/Full_Stack_Sinatra_App_Skeletons/Skeleton_App_with_user_login:sign_up_and_bcrypt/Rakefile
+++ b/Full_Stack_Sinatra_App_Skeletons/Skeleton_App_with_user_login:sign_up_and_bcrypt/Rakefile
@@ -15,3 +15,48 @@ namespace :db do
     puts "Auto-migrate complete (data was lost), Wayne Rumble was here. LOL"
   end
 end
+
+namespace :helper do
+  desc "Database creation and setup helper"
+  task :setup_db do
+    if db_exists
+      puts "WARNING: at least one database with the given name already exists, use $rake helper:drop_db if you want to remove them"
+    else
+      create_db 'development'
+      migrate_db 'development'
+      create_db 'test'
+      migrate_db 'test'
+    end
+  end
+
+  desc "Database dropping helper"
+  task :drop_db do
+    drop_db 'development'
+    drop_db 'test'
+  end
+end
+
+def db_exists
+  `psql -c "SELECT 1 FROM pg_database WHERE datname = 'skeleton_app_test'"`.include? '1' or
+  `psql -c "SELECT 1 FROM pg_database WHERE datname = 'skeleton_app_development'"`.include? '1'
+end
+
+def drop_db env
+  print "Dropping skeleton_app_#{env} database..."
+  `psql -c 'DROP DATABASE skeleton_app_#{env}'`
+  puts "Done."
+end
+
+def create_db env
+  print "Creating skeleton_app_#{env} database..."
+  `psql -c 'CREATE DATABASE skeleton_app_#{env}'`
+  puts "Done."
+end
+
+def migrate_db env
+  print "Migrating skeleton_app_#{env} tables..."
+  DataMapper.setup :default, "postgres://localhost/skeleton_app_#{env}"
+  DataMapper.finalize
+  DataMapper.auto_migrate!
+  puts "Done."
+end


### PR DESCRIPTION
Create a couple of new helper commands and update readme:
- helper:setup_db automatically creates and migrates both databases, stopping if any already exists.
- helper:drop_db removes both databases to allow for a fresh install.

Please doublecheck their working, I'm quite sure you need to run those commands from a users that has the right access rights to the postgres interface since it runs some bash commands.
